### PR TITLE
Add drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/icons": "^1.0.0-beta.42",
     "axios": "^0.18.0",
     "bootstrap": "^4.0.0",
     "downloadjs": "^1.4.7",

--- a/src/App.css
+++ b/src/App.css
@@ -21,3 +21,39 @@
 table, thead, tbody {
 	display: block !important;
 }
+
+.ol-control{
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.ol-zoom{
+  left: unset;
+  right: .5em;
+}
+
+.ol-rotate{
+  top: 4.875em;
+}
+
+.ol-geocoder{
+  position: unset !important;
+}
+
+.gcd-gl-control{
+  position: relative;
+  float: left;
+  width: 16.5em !important;
+  background: none
+}
+
+.gcd-gl-input{
+  width: 16em !important;
+}
+
+
+
+#searchLocations{
+  position: absolute;
+  right: 4em;
+  top: 1em;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -39,11 +39,16 @@ table, thead, tbody {
   position: unset !important;
 }
 
+.gcd-gl-btn{
+  height:2em !important;
+  width: 2em !important;
+}
+
 .gcd-gl-control{
   position: relative;
   float: left;
   width: 16.5em !important;
-  background: none
+  background: none !important;
 }
 
 .gcd-gl-input{

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import './App.css';
 import Container from './components/Container';
 
+
 class App extends Component {
   render() {
     return (

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -197,15 +197,16 @@ class Container extends React.Component {
     })
   }
 
-  changeMode = () => {
+  changeMode = (mode) => {
     this.setState({
-      mode: false
+      mode,
+      canCreate: false
     })
   }
 
-  trailSelected = () => {
+  trailSelected = (id) => {
     this.setState({
-      selectedTrail: this.state.id,
+      selectedTrail: id,
       canCreate: false
     })
   }

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -9,6 +9,7 @@ import TrailList from './TrailList';
 import { getElevation, getMapStyle } from '../utils/mapUtils';
 import { Trail, Hydrant } from '../utils/records';
 import ImportExport from './ImportExport';
+import Drawer from './Drawer';
 
 class Container extends React.Component {
   constructor(props) {
@@ -190,10 +191,52 @@ class Container extends React.Component {
     });
   }
 
-  render(){
+  toggleCreate = () => {
+    this.setState({
+      canCreate: !this.state.canCreate
+    })
+  }
+
+  changeMode = () => {
+    this.setState({
+      mode: false
+    })
+  }
+
+  trailSelected = () => {
+    this.setState({
+      selectedTrail: this.state.id,
+      canCreate: false
+    })
+  }
+
+  render() {
     const { trails, mode, selectedTrail, hydrants, canCreate } = this.state;
 
     return (
+      <Drawer
+        mode={mode}
+        canCreate={canCreate || mode === 'hydrants'}
+        toggleCreate={this.toggleCreate}
+        trailSelected={this.trailSelected}
+        createObject={this.createObject}
+        modifyTrail={this.modifyTrail}
+        modifyHydrant={this.modifyHydrant}
+        trails={trails}
+        hydrants={hydrants}
+        selectedTrail={selectedTrail}
+        changeMode={this.changeMode}
+        importKMLClicked={this.importKMLClicked}
+      />
+    );
+  }
+}
+
+export default Container;
+
+
+
+/*
       <div>
         <Grid container spacing={0} style={{maxHeight: '600px'}}>
           <Grid item xs={3}>
@@ -233,7 +276,29 @@ class Container extends React.Component {
          />
         </div>
     );
-  }
-}
 
-export default Container;
+
+    <div>
+      <OpenLayersMap
+        mode={mode}
+        canCreate={canCreate || mode === 'hydrants'}
+        createObject={this.createObject}
+        modifyTrail={this.modifyTrail}
+        modifyHydrant={this.modifyHydrant}
+        trails={trails}
+        hydrants={hydrants}
+        selectedTrail={selectedTrail}
+      />
+
+      <MapControls
+        mode={mode}
+        changeMode={(mode) => this.setState({ mode, canCreate: false })}
+      />
+
+      <ImportExport
+        importKMLClicked= {this.importKMLClicked}
+        trails = {trails}
+        hydrants = {hydrants}
+       />
+     </div>
+        */

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -11,6 +11,7 @@ import { Trail, Hydrant } from '../utils/records';
 import ImportExport from './ImportExport';
 import Drawer from './Drawer';
 
+
 class Container extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import classNames from 'classnames';
+import Drawer from 'material-ui/Drawer';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import List from 'material-ui/List';
+import Typography from 'material-ui/Typography';
+import Divider from 'material-ui/Divider';
+import IconButton from 'material-ui/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import TrailList from './TrailList';
+import OpenLayersMap from './OpenLayersMap';
+import MapControls from './MapControls';
+import ImportExport from './ImportExport';
+
+
+const drawerWidth = 240;
+
+const styles = theme => ({
+  root: {
+    flexGrow: 1,
+    zIndex: 1,
+    overflow: 'hidden',
+    position: 'relative',
+    display: 'flex',
+  },
+  appBar: {
+    zIndex: theme.zIndex.drawer + 1,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  appBarShift: {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  menuButton: {
+    marginLeft: 12,
+    marginRight: 36,
+  },
+  hide: {
+    display: 'none',
+  },
+  drawerPaper: {
+    position: 'relative',
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  drawerPaperClose: {
+    overflowX: 'hidden',
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    width: theme.spacing.unit * 7,
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing.unit * 9,
+    },
+  },
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: '0 8px',
+    ...theme.mixins.toolbar,
+  },
+  content: {
+    flexGrow: 1,
+    backgroundColor: theme.palette.background.default,
+    padding: theme.spacing.unit * 3,
+  },
+});
+
+
+class MiniDrawer extends React.Component {
+  state = {
+    open: false,
+  };
+
+  handleDrawerOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleDrawerClose = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    const { classes, theme, modifyTrail, canCreate, trails, mode, hydrants,
+      selectedTrail, toggleCreate, createObject, modifyHydrant, changeMode, importKMLClicked,
+      trailSelected } = this.props;
+
+    console.log(this.props)
+    return (
+      <div className={classes.root}>
+        <AppBar
+          position="absolute"
+          className={classNames(classes.appBar, this.state.open && classes.appBarShift)}
+        >
+          <Toolbar disableGutters={!this.state.open}>
+            <IconButton
+              color="inherit"
+              aria-label="open drawer"
+              onClick={this.handleDrawerOpen}
+              className={classNames(classes.menuButton, this.state.open && classes.hide)}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="title" color="inherit" noWrap>
+              SnoTrack
+            </Typography>
+          </Toolbar>
+        </AppBar>
+        <Drawer
+          variant="permanent"
+          classes={{
+            paper: classNames(classes.drawerPaper, !this.state.open && classes.drawerPaperClose),
+          }}
+          open={this.state.open}
+        >
+          <div className={classes.toolbar}>
+            <IconButton onClick={this.handleDrawerClose}>
+              {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+            </IconButton>
+          </div>
+
+          <TrailList
+            modifyTrail={modifyTrail}
+            canCreate={canCreate}
+            toggleCreate={toggleCreate}
+            trails={trails}
+            trailSelected={trailSelected}
+            mode={mode}
+            hydrants={hydrants}
+            selected={selectedTrail}
+          />
+
+        </Drawer>
+        <main className={classes.content}>
+          <div className={classes.toolbar} />
+
+          <OpenLayersMap
+            mode={mode}
+            canCreate={canCreate}
+            createObject={createObject}
+            modifyTrail={modifyTrail}
+            modifyHydrant={modifyHydrant}
+            trails={trails}
+            hydrants={hydrants}
+            selectedTrail={selectedTrail}
+          />
+
+          <MapControls
+            mode={mode}
+            changeMode={changeMode}
+          />
+
+          <ImportExport
+            importKMLClicked= {importKMLClicked}
+            trails = {trails}
+            hydrants = {hydrants}
+           />
+
+
+        </main>
+      </div>
+    );
+  }
+}
+
+
+export default withStyles(styles, { withTheme: true })(MiniDrawer);
+
+
+
+
+// <TrailList
+//   modifyTrail={this.modifyTrail}
+//   canCreate={canCreate}
+//   toggleCreate={() => this.setState({canCreate: !canCreate})}
+//   trails={trails}
+//   mode={mode}
+//   hydrants={hydrants}
+//   selected={selectedTrail}
+//   trailSelected={(id) => this.setState({ selectedTrail: id, canCreate: false })}
+// />

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,51 +1,62 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import classNames from 'classnames';
 import Drawer from 'material-ui/Drawer';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import List from 'material-ui/List';
+import { MenuItem } from 'material-ui/Menu';
 import Typography from 'material-ui/Typography';
+import TextField from 'material-ui/TextField';
 import Divider from 'material-ui/Divider';
 import IconButton from 'material-ui/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+
+
 import TrailList from './TrailList';
 import OpenLayersMap from './OpenLayersMap';
 import MapControls from './MapControls';
 import ImportExport from './ImportExport';
 
-
-const drawerWidth = 240;
+const drawerWidth = 350;
 
 const styles = theme => ({
   root: {
     flexGrow: 1,
+  },
+  appFrame: {
     zIndex: 1,
     overflow: 'hidden',
     position: 'relative',
     display: 'flex',
+    width: '100%',
   },
   appBar: {
-    zIndex: theme.zIndex.drawer + 1,
-    transition: theme.transitions.create(['width', 'margin'], {
+    background: '#040404',
+    position: 'absolute',
+    transition: theme.transitions.create(['margin', 'width'], {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen,
     }),
   },
   appBarShift: {
-    marginLeft: drawerWidth,
     width: `calc(100% - ${drawerWidth}px)`,
-    transition: theme.transitions.create(['width', 'margin'], {
-      easing: theme.transitions.easing.sharp,
+    transition: theme.transitions.create(['margin', 'width'], {
+      easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
     }),
   },
+  'appBarShift-left': {
+    marginLeft: drawerWidth,
+  },
+  'appBarShift-right': {
+    marginRight: drawerWidth,
+  },
   menuButton: {
     marginLeft: 12,
-    marginRight: 36,
+    marginRight: 20,
   },
   hide: {
     display: 'none',
@@ -53,23 +64,8 @@ const styles = theme => ({
   drawerPaper: {
     position: 'relative',
     width: drawerWidth,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
   },
-  drawerPaperClose: {
-    overflowX: 'hidden',
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    width: theme.spacing.unit * 7,
-    [theme.breakpoints.up('sm')]: {
-      width: theme.spacing.unit * 9,
-    },
-  },
-  toolbar: {
+  drawerHeader: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
@@ -79,14 +75,35 @@ const styles = theme => ({
   content: {
     flexGrow: 1,
     backgroundColor: theme.palette.background.default,
-    padding: theme.spacing.unit * 3,
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  'content-left': {
+    marginLeft: -drawerWidth,
+  },
+  'content-right': {
+    marginRight: -drawerWidth,
+  },
+  contentShift: {
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  'contentShift-left': {
+    marginLeft: 0,
+  },
+  'contentShift-right': {
+    marginRight: 0,
   },
 });
 
-
-class MiniDrawer extends React.Component {
+class PersistentDrawer extends React.Component {
   state = {
     open: false,
+    anchor: 'left',
   };
 
   handleDrawerOpen = () => {
@@ -97,102 +114,146 @@ class MiniDrawer extends React.Component {
     this.setState({ open: false });
   };
 
+  handleChangeAnchor = event => {
+    this.setState({
+      anchor: event.target.value,
+    });
+  };
+
   render() {
+
     const { classes, theme, modifyTrail, canCreate, trails, mode, hydrants,
       selectedTrail, toggleCreate, createObject, modifyHydrant, changeMode, importKMLClicked,
-      trailSelected } = this.props;
+      trailSelected } = this.props
 
-    console.log(this.props)
+    const { anchor, open } = this.state;
+
+    const drawer = (
+      <Drawer
+        variant="persistent"
+        anchor={anchor}
+        open={open}
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+      >
+        <div className={classes.drawerHeader}>
+          <IconButton onClick={this.handleDrawerClose}>
+            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </div>
+        <TrailList
+          modifyTrail={modifyTrail}
+          canCreate={canCreate}
+          toggleCreate={toggleCreate}
+          trails={trails}
+          trailSelected={trailSelected}
+          mode={mode}
+          hydrants={hydrants}
+          selected={selectedTrail}
+        />
+      </Drawer>
+    );
+
+
+    let before = null;
+    let after = null;
+
+    if (anchor === 'left') {
+      before = drawer;
+    } else {
+      after = drawer;
+    }
+
     return (
       <div className={classes.root}>
-        <AppBar
-          position="absolute"
-          className={classNames(classes.appBar, this.state.open && classes.appBarShift)}
-        >
-          <Toolbar disableGutters={!this.state.open}>
-            <IconButton
-              color="inherit"
-              aria-label="open drawer"
-              onClick={this.handleDrawerOpen}
-              className={classNames(classes.menuButton, this.state.open && classes.hide)}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography variant="title" color="inherit" noWrap>
-              SnoTrack
-            </Typography>
-          </Toolbar>
-        </AppBar>
-        <Drawer
-          variant="permanent"
-          classes={{
-            paper: classNames(classes.drawerPaper, !this.state.open && classes.drawerPaperClose),
-          }}
-          open={this.state.open}
-        >
-          <div className={classes.toolbar}>
-            <IconButton onClick={this.handleDrawerClose}>
-              {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-            </IconButton>
-          </div>
+        <div className={classes.appFrame}>
+          <AppBar
+            className={classNames(classes.appBar, {
+              [classes.appBarShift]: open,
+              [classes[`appBarShift-${anchor}`]]: open,
+            })}
+          >
+            <Toolbar disableGutters={!open}>
+              <IconButton
+                color="inherit"
+                aria-label="open drawer"
+                onClick={this.handleDrawerOpen}
+                className={classNames(classes.menuButton, open && classes.hide)}
+              >
+                <MenuIcon />
+              </IconButton>
+              <Typography variant="title" color="inherit" noWrap>
+                SnoTrack
+              </Typography>
+            </Toolbar>
+          </AppBar>
+          {before}
+          <main
+            className={classNames(classes.content, classes[`content-${anchor}`], {
+              [classes.contentShift]: open,
+              [classes[`contentShift-${anchor}`]]: open,
+            })}
+          >
+            <div className={classes.drawerHeader} />
 
-          <TrailList
-            modifyTrail={modifyTrail}
-            canCreate={canCreate}
-            toggleCreate={toggleCreate}
-            trails={trails}
-            trailSelected={trailSelected}
-            mode={mode}
-            hydrants={hydrants}
-            selected={selectedTrail}
-          />
+            <OpenLayersMap
+              mode={mode}
+              canCreate={canCreate}
+              createObject={createObject}
+              modifyTrail={modifyTrail}
+              modifyHydrant={modifyHydrant}
+              trails={trails}
+              hydrants={hydrants}
+              selectedTrail={selectedTrail}
+            />
 
-        </Drawer>
-        <main className={classes.content}>
-          <div className={classes.toolbar} />
+            <MapControls
+              mode={mode}
+              changeMode={changeMode}
+            />
 
-          <OpenLayersMap
-            mode={mode}
-            canCreate={canCreate}
-            createObject={createObject}
-            modifyTrail={modifyTrail}
-            modifyHydrant={modifyHydrant}
-            trails={trails}
-            hydrants={hydrants}
-            selectedTrail={selectedTrail}
-          />
+            <ImportExport
+              importKMLClicked={importKMLClicked}
+              trails={trails}
+              hydrants={hydrants}
+            />
 
-          <MapControls
-            mode={mode}
-            changeMode={changeMode}
-          />
-
-          <ImportExport
-            importKMLClicked= {importKMLClicked}
-            trails = {trails}
-            hydrants = {hydrants}
-           />
-
-
-        </main>
+          </main>
+          {after}
+        </div>
       </div>
     );
   }
 }
 
-
-export default withStyles(styles, { withTheme: true })(MiniDrawer);
-
+export default withStyles(styles, { withTheme: true })(PersistentDrawer);
 
 
-
-// <TrailList
-//   modifyTrail={this.modifyTrail}
-//   canCreate={canCreate}
-//   toggleCreate={() => this.setState({canCreate: !canCreate})}
-//   trails={trails}
+//
+// const { classes, theme, modifyTrail, canCreate, trails, mode, hydrants,
+//   selectedTrail, toggleCreate, createObject, modifyHydrant, changeMode, importKMLClicked,
+//   trailSelected } = this.props;
+//
+// <OpenLayersMap
 //   mode={mode}
+//   canCreate={canCreate}
+//   createObject={createObject}
+//   modifyTrail={modifyTrail}
+//   modifyHydrant={modifyHydrant}
+//   trails={trails}
 //   hydrants={hydrants}
-//   selected={selectedTrail}
-//   trailSelected={(id) => this.setState({ selectedTrail: id, canCreate: false })}
+//   selectedTrail={selectedTrail}
 // />
+//
+// <MapControls
+//   mode={mode}
+//   changeMode={changeMode}
+// />
+//
+// <ImportExport
+//   importKMLClicked= {importKMLClicked}
+//   trails = {trails}
+//   hydrants = {hydrants}
+//  />
+//

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -72,7 +72,6 @@ const styles = theme => ({
 class PersistentDrawer extends React.Component {
   state = {
     open: false,
-    anchor: 'left',
   };
 
   handleDrawerOpen = () => {
@@ -81,12 +80,6 @@ class PersistentDrawer extends React.Component {
 
   handleDrawerClose = () => {
     this.setState({ open: false });
-  };
-
-  handleChangeAnchor = event => {
-    this.setState({
-      anchor: event.target.value,
-    });
   };
 
   render() {
@@ -101,12 +94,12 @@ class PersistentDrawer extends React.Component {
       'hydrants': 'Hydrants',
     }
 
-    const { anchor, open } = this.state;
+    const { open } = this.state;
 
     const drawer = (
       <Drawer
         variant="persistent"
-        anchor={anchor}
+        anchor='left'
         open={open}
         classes={{
           paper: classes.drawerPaper,
@@ -114,21 +107,21 @@ class PersistentDrawer extends React.Component {
       >
         <div className={classes.drawerHeader}>
 
-        <Tooltip title="Auto Associate Hydrants" placement="top-start">
-          <IconButton>
-            <CallMerge />
-          </IconButton>
-        </Tooltip>
+          <Tooltip title="Auto Associate Hydrants" placement="top-start">
+            <IconButton>
+              <CallMerge />
+            </IconButton>
+          </Tooltip>
 
-        <ImportExport
-          importKMLClicked={importKMLClicked}
-          trails={trails}
-          hydrants={hydrants}
-        />
+          <ImportExport
+            importKMLClicked={importKMLClicked}
+            trails={trails}
+            hydrants={hydrants}
+          />
 
-        <Typography variant="title" color="inherit">
-          {drawerHeaderTitle[mode]}
-        </Typography>
+          <Typography variant="title" color="inherit">
+            {drawerHeaderTitle[mode]}
+          </Typography>
           <IconButton onClick={this.handleDrawerClose}>
             {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
           </IconButton>
@@ -148,23 +141,13 @@ class PersistentDrawer extends React.Component {
       </Drawer>
     );
 
-
-    let before = null;
-    let after = null;
-
-    if (anchor === 'left') {
-      before = drawer;
-    } else {
-      after = drawer;
-    }
-
     return (
       <div className={classes.root}>
         <div className={classes.appFrame}>
           <AppBar
             className={classNames(classes.appBar, {
               [classes.appBarShift]: open,
-              [classes[`appBarShift-${anchor}`]]: open,
+              [classes[`appBarShift-left`]]: open,
             })}
           >
             <Toolbar disableGutters={!open}>
@@ -186,11 +169,11 @@ class PersistentDrawer extends React.Component {
             </Toolbar>
             <div id="searchLocations"></div>
           </AppBar>
-          {before}
+          {drawer}
           <main
-            className={classNames(classes.content, classes[`content-${anchor}`], {
+            className={classNames(classes.content, classes[`content-left`], {
               [classes.contentShift]: open,
-              [classes[`contentShift-${anchor}`]]: open,
+              [classes[`contentShift-left`]]: open,
             })}
           >
             <div className={classes.drawerHeader} />
@@ -207,7 +190,7 @@ class PersistentDrawer extends React.Component {
             />
 
           </main>
-          {after}
+          {drawer}
         </div>
       </div>
     );

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -26,6 +26,12 @@ const styles = theme => ({
   root: {
     flexGrow: 1,
   },
+  paperAnchorDockedLeft: {
+    background: 'black',
+  },
+  drawerPaper: {
+    background: '#ffffffde',
+  },
   appBar: {
     background: '#040404',
     position: 'absolute',
@@ -57,6 +63,7 @@ const styles = theme => ({
     justifyContent: 'flex-end',
     padding: '0 8px',
     ...theme.mixins.toolbar,
+    background: 'white'
   }
 });
 
@@ -87,6 +94,12 @@ class PersistentDrawer extends React.Component {
       selectedTrail, toggleCreate, createObject, modifyHydrant, changeMode, importKMLClicked,
       trailSelected } = this.props
 
+
+    const drawerHeaderTitle = {
+      'trails': 'Trails',
+      'hydrants': 'Hydrants',
+    }
+
     const { anchor, open } = this.state;
 
     const drawer = (
@@ -99,10 +112,21 @@ class PersistentDrawer extends React.Component {
         }}
       >
         <div className={classes.drawerHeader}>
+        <Typography variant="title" color="inherit">
+          {drawerHeaderTitle[mode]}
+        </Typography>
+
           <IconButton onClick={this.handleDrawerClose}>
             {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
           </IconButton>
         </div>
+
+        <ImportExport
+          importKMLClicked={importKMLClicked}
+          trails={trails}
+          hydrants={hydrants}
+        />
+
         <TrailList
           modifyTrail={modifyTrail}
           canCreate={canCreate}
@@ -147,6 +171,10 @@ class PersistentDrawer extends React.Component {
               <Typography variant="title" color="inherit" noWrap>
                 SnoTrack
               </Typography>
+              <MapControls
+                mode={mode}
+                changeMode={changeMode}
+              />
             </Toolbar>
             <div id="searchLocations"></div>
           </AppBar>
@@ -168,17 +196,6 @@ class PersistentDrawer extends React.Component {
               trails={trails}
               hydrants={hydrants}
               selectedTrail={selectedTrail}
-            />
-
-            <MapControls
-              mode={mode}
-              changeMode={changeMode}
-            />
-
-            <ImportExport
-              importKMLClicked={importKMLClicked}
-              trails={trails}
-              hydrants={hydrants}
             />
 
           </main>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -20,18 +20,11 @@ import OpenLayersMap from './OpenLayersMap';
 import MapControls from './MapControls';
 import ImportExport from './ImportExport';
 
-const drawerWidth = 350;
+const drawerWidth = 300;
 
 const styles = theme => ({
   root: {
     flexGrow: 1,
-  },
-  appFrame: {
-    zIndex: 1,
-    overflow: 'hidden',
-    position: 'relative',
-    display: 'flex',
-    width: '100%',
   },
   appBar: {
     background: '#040404',
@@ -48,9 +41,6 @@ const styles = theme => ({
       duration: theme.transitions.duration.enteringScreen,
     }),
   },
-  'appBarShift-left': {
-    marginLeft: drawerWidth,
-  },
   'appBarShift-right': {
     marginRight: drawerWidth,
   },
@@ -61,44 +51,15 @@ const styles = theme => ({
   hide: {
     display: 'none',
   },
-  drawerPaper: {
-    position: 'relative',
-    width: drawerWidth,
-  },
   drawerHeader: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     padding: '0 8px',
     ...theme.mixins.toolbar,
-  },
-  content: {
-    flexGrow: 1,
-    backgroundColor: theme.palette.background.default,
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  'content-left': {
-    marginLeft: -drawerWidth,
-  },
-  'content-right': {
-    marginRight: -drawerWidth,
-  },
-  contentShift: {
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  'contentShift-left': {
-    marginLeft: 0,
-  },
-  'contentShift-right': {
-    marginRight: 0,
-  },
+  }
 });
+
 
 class PersistentDrawer extends React.Component {
   state = {
@@ -187,6 +148,7 @@ class PersistentDrawer extends React.Component {
                 SnoTrack
               </Typography>
             </Toolbar>
+            <div id="searchLocations"></div>
           </AppBar>
           {before}
           <main
@@ -228,32 +190,3 @@ class PersistentDrawer extends React.Component {
 }
 
 export default withStyles(styles, { withTheme: true })(PersistentDrawer);
-
-
-//
-// const { classes, theme, modifyTrail, canCreate, trails, mode, hydrants,
-//   selectedTrail, toggleCreate, createObject, modifyHydrant, changeMode, importKMLClicked,
-//   trailSelected } = this.props;
-//
-// <OpenLayersMap
-//   mode={mode}
-//   canCreate={canCreate}
-//   createObject={createObject}
-//   modifyTrail={modifyTrail}
-//   modifyHydrant={modifyHydrant}
-//   trails={trails}
-//   hydrants={hydrants}
-//   selectedTrail={selectedTrail}
-// />
-//
-// <MapControls
-//   mode={mode}
-//   changeMode={changeMode}
-// />
-//
-// <ImportExport
-//   importKMLClicked= {importKMLClicked}
-//   trails = {trails}
-//   hydrants = {hydrants}
-//  />
-//

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -13,7 +13,8 @@ import IconButton from 'material-ui/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
-
+import Tooltip from 'material-ui/Tooltip';
+import CallMerge from '@material-ui/icons/CallMerge';
 
 import TrailList from './TrailList';
 import OpenLayersMap from './OpenLayersMap';
@@ -112,20 +113,27 @@ class PersistentDrawer extends React.Component {
         }}
       >
         <div className={classes.drawerHeader}>
-        <Typography variant="title" color="inherit">
-          {drawerHeaderTitle[mode]}
-        </Typography>
 
-          <IconButton onClick={this.handleDrawerClose}>
-            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+        <Tooltip title="Auto Associate Hydrants" placement="top-start">
+          <IconButton>
+            <CallMerge />
           </IconButton>
-        </div>
+        </Tooltip>
 
         <ImportExport
           importKMLClicked={importKMLClicked}
           trails={trails}
           hydrants={hydrants}
         />
+
+        <Typography variant="title" color="inherit">
+          {drawerHeaderTitle[mode]}
+        </Typography>
+          <IconButton onClick={this.handleDrawerClose}>
+            {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+
+        </div>
 
         <TrailList
           modifyTrail={modifyTrail}

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -18,7 +18,9 @@ import { FormGroup, FormControlLabel } from 'material-ui/Form';
 import { withStyles } from 'material-ui/styles';
 import {Trail, Hydrant} from '../utils/records';
 import downloadjs from 'downloadjs';
-
+import ImportExportIcon from '@material-ui/icons/ImportExport';
+import Tooltip from 'material-ui/Tooltip';
+import IconButton from 'material-ui/IconButton';
 
 
 class ImportExport extends React.Component {
@@ -169,7 +171,11 @@ class ImportExport extends React.Component {
     return (
       <div>
           <div style={style}>
-            <Button variant="raised" onClick={this.handleOpen}>Import / Export</Button>
+          <Tooltip title="Import/Export" placement="top-start">
+          <IconButton onClick={this.handleOpen}>
+             <ImportExportIcon />
+            </IconButton>
+          </Tooltip>
           </div>
           <Dialog onBackdropClick={this.handleClose} aria-labelledby="simple-dialog-title" open={dialogueMain} >
             <DialogTitle id="simple-dialog-title">Import/Export</DialogTitle>

--- a/src/components/MapControls.js
+++ b/src/components/MapControls.js
@@ -4,7 +4,7 @@ import { Button } from 'material-ui';
 class MapControls extends React.Component{
   render(){
     let style= {
-      float: 'left'
+      margin: '0 auto'
     }
 
     const {changeMode, mode} = this.props;
@@ -23,7 +23,6 @@ class MapControls extends React.Component{
             onClick={()=> changeMode('hydrants')}>
             Hydrants
           </Button>
-          <Button variant="raised">Auto-associate hydrants</Button>
         </div>
     )
   }

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -103,6 +103,10 @@ class OpenLayersMap extends React.Component {
       autoComplete: true,
     });
 
+    geocoder.setTarget(document.getElementById('searchLocations'))
+
+    console.log(geocoder)
+
     const resortLayer = new LayerVector({
       source,
       style: getMapStyle,

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -105,8 +105,6 @@ class OpenLayersMap extends React.Component {
 
     geocoder.setTarget(document.getElementById('searchLocations'))
 
-    console.log(geocoder)
-
     const resortLayer = new LayerVector({
       source,
       style: getMapStyle,


### PR DESCRIPTION
This PR adds a MUI drawer on the right side of the screen and seperates out the state buttons from the tool buttons.  Tool buttons (auto merge/import export) and the trail list components have been moved into the drawer sidebar, the map components have been moved to the drawer main container, and the state buttons (trail/ hydrants) and search bar have been moved to the app bar contained.