### PR TITLE
Add snap

### DIFF
--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -66,7 +66,8 @@ class OpenLayersMap extends React.Component {
 
     if (mode === 'trails') {
       const snap = new Snap({
-        source
+        source,
+        pixelTolerance: 5
       })
       newInteractions.push(snap);
     }

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -12,6 +12,7 @@ import Projection from 'ol/proj';
 import SourceVector from 'ol/source/vector';
 import Draw from 'ol/interaction/draw';
 import Modify from 'ol/interaction/modify';
+import Snap from 'ol/interaction/snap';
 import Geocoder from 'ol-geocoder';
 import { getMapStyle } from '../utils/mapUtils';
 
@@ -61,6 +62,13 @@ class OpenLayersMap extends React.Component {
       const modify = new Modify({ features: modifiable });
       modify.on('modifyend', (e) => this.endModify(e));
       newInteractions.push(modify);
+    }
+
+    if (mode === 'trails') {
+      const snap = new Snap({
+        source
+      })
+      newInteractions.push(snap);
     }
 
     _.each(newInteractions, (interaction) => map.addInteraction(interaction));


### PR DESCRIPTION
Added snap interaction when app is in trails mode. Adding it by default (and having hydrants also snap) is unnecessary I think and gets slow when dragging hydrants around.