### PR TITLE
Multi trails

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -68,7 +68,7 @@ class Container extends React.Component {
       });
       const name = 'New Trail';
       const newTrail = new Trail({
-        id, name, coords, feature,
+        id, name, feature,
       });
       feature.setId(`t${id}`);
       addTrail(newTrail);
@@ -117,20 +117,20 @@ class Container extends React.Component {
 
   toggleCreate = () => {
     this.setState({
-      canCreate: !this.state.canCreate
-    })
+      canCreate: !this.state.canCreate,
+    });
   }
 
   changeMode = (mode) => {
     this.setState({
       mode,
-      canCreate: false
-    })
+      canCreate: false,
+    });
   }
 
   trailSelected = (id) => {
-    this.props.trailSelected(this.props.selectedTrail, id),
-    this.setState({canCreate: false});
+    this.props.trailSelected(this.props.selectedTrail, id);
+    this.setState({ canCreate: false });
   }
 
   render() {
@@ -177,7 +177,7 @@ const mapDispatchToProps = dispatch => ({
   trailSelected: (prevSelected, id) => dispatch({
     type: TRAIL_SELECTED, data: { prevSelected, selected: id },
   }),
-  dataImported: data => ({
+  dataImported: data => dispatch({
     type: DATA_IMPORTED, data,
   }),
 });

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -75,7 +75,7 @@ class ImportExport extends React.Component {
     reader.onload = (event) => {
       try {
         const kml = new KML().readFeatures(event.target.result);
-        let newTrails = {};
+        const newTrails = {};
         const newHydrants = {};
 
         _.each(kml, (feature, index) => {
@@ -95,7 +95,6 @@ class ImportExport extends React.Component {
                   newHydrants[h.get('id')] = h.set('trail', trail.get('id'));
                 });
             }
-            
           } else {
             const hydrant = processHydrant(feature, index);
             newHydrants[hydrant.get('id')] = hydrant;

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -2,25 +2,20 @@ import React from 'react';
 import { Button } from 'material-ui';
 import KML from 'ol/format/kml';
 import _ from 'lodash';
-import {Coordinate} from 'ol';
 import Immutable from 'immutable';
-import Feature from 'ol/feature';
-import Point from 'ol/geom/point';
 import Projection from 'ol/proj';
-import Polygon from 'ol/geom/polygon';
-import GeometryCollection from 'ol/geom/geometrycollection';
-import {getMapStyle} from '../utils/mapUtils';
+import MultiPolygon from 'ol/geom/multipolygon';
 import Dialog, { DialogTitle } from 'material-ui/Dialog';
 import Divider from 'material-ui/Divider';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Radio from 'material-ui/Radio';
 import { FormGroup, FormControlLabel } from 'material-ui/Form';
-import { withStyles } from 'material-ui/styles';
-import {Trail, Hydrant} from '../utils/records';
 import downloadjs from 'downloadjs';
 import ImportExportIcon from '@material-ui/icons/ImportExport';
 import Tooltip from 'material-ui/Tooltip';
 import IconButton from 'material-ui/IconButton';
+import { getMapStyle } from '../utils/mapUtils';
+import { Trail, Hydrant } from '../utils/records';
 
 
 class ImportExport extends React.Component {
@@ -32,7 +27,7 @@ class ImportExport extends React.Component {
       exportType: null,
       dialogOpen: false,
       selectedExport: 'trails',
-    }
+    };
     this.changeFile = this.changeFile.bind(this);
     this.importFile = this.importFile.bind(this);
   }
@@ -51,13 +46,27 @@ class ImportExport extends React.Component {
       let [name, ...otherThings] = feature.get('description').split(',');
       name = _.words(name).join(' ');
       const id = index + name;
-      const coords = feature.getGeometry().getCoordinates()[0];
-      const lonLatCoords = _.map(coords, pt => Projection.fromLonLat(pt.slice(0,2)));
-      feature.getGeometry().setCoordinates([lonLatCoords]);
+      if (feature.getGeometry().getType() !== 'MultiPolygon') {
+        const newGeometry = new MultiPolygon();
+        newGeometry.appendPolygon(feature.getGeometry());
+        feature.setGeometry(newGeometry);
+      }
+      _.each(feature.getGeometry().getPolygons(), (polygon) => {
+        // make correction if coordinates are returned in 3d
+        // but the geometry is expecting 2d
+        if (polygon.flatCoordinates[2] === 0 && polygon.getLayout() !== "XYZ") {
+          polygon.setLayout("XYZ");
+        }
+        const coords = polygon.getCoordinates()[0];
+        const lonLatCoords = _.map(coords, pt => Projection.fromLonLat(pt.slice(0,2)));
+        polygon.setCoordinates([lonLatCoords]);
+        polygon.setLayout("XY");
+      });
       feature.setId(`t${id}`);
       feature.set('name', name);
+      console.log(getMapStyle);
       feature.setStyle(getMapStyle);
-      return new Trail({ id, name, coords, feature });
+      return new Trail({ id, name, feature });
     }
 
     function processHydrant(feature, index) {
@@ -73,7 +82,7 @@ class ImportExport extends React.Component {
       feature.getGeometry().setCoordinates(Projection.fromLonLat(coords.slice(0,2)));
       feature.setId(`h${id}`);
       feature.set('trailName', trailName);
-      feature.setStyle(getMapStyle)
+      feature.setStyle(getMapStyle);
       return new Hydrant({ id, name, coords, feature, trail: trailId });
     }
 
@@ -116,43 +125,35 @@ class ImportExport extends React.Component {
   }
 
   exportFile = () => {
-    const { trails, hydrants } = this.props
-    const { selectedExport } = this.state
+    const { trails, hydrants } = this.props;
+    const { selectedExport } = this.state;
 
-
-    const trailFeatures = _.values(trails.toJS()).map((item)=> {
-      return item.feature
-    })
-
-    const hydrantFeatures  = _.values(hydrants.toJS()).map((item)=> {
-      return item.feature
-      })
-
-
-   if(selectedExport === 'trails'){
-     downloadjs(GetKMLFromFeatures(trailFeatures), 'Trails.kml')
-   } else {
-     downloadjs(GetKMLFromFeatures(hydrantFeatures), 'Hydrants.kml')
-   }
+    const trailFeatures = _.values(trails.toJS()).map(item => item.feature);
+    const hydrantFeatures = _.values(hydrants.toJS()).map(item => item.feature);
 
     function GetKMLFromFeatures(features) {
-          const format = new KML();
-          const kml = format.writeFeatures(features, {featureProjection: 'EPSG:3857'});
-          return kml;
-      }
+      const format = new KML();
+      const kml = format.writeFeatures(features, {featureProjection: 'EPSG:3857'});
+      return kml;
+    }
 
+    if (selectedExport === 'trails') {
+      downloadjs(GetKMLFromFeatures(trailFeatures), 'Trails.kml');
+    } else {
+      downloadjs(GetKMLFromFeatures(hydrantFeatures), 'Hydrants.kml');
+    }
   }
 
   handleClose = () => {
     this.setState({
-      dialogOpen: false
-    })
+      dialogOpen: false,
+    });
   }
 
   handleOpen = () => {
     this.setState({
-      dialogOpen: true
-    })
+      dialogOpen: true,
+    });
   }
 
   handleSelect = event => {
@@ -182,7 +183,7 @@ class ImportExport extends React.Component {
               <List>
                 <ListItem>
                   <ListItemText primary='Import' />
-                  <input onChange={this.changeFile} type='file' />
+                  <input onChange={this.changeFile} type="file" accept=".kml" />
                   <Button variant="raised" onClick={this.importFile} > Import </Button>
                 </ListItem>
                 <li>
@@ -217,7 +218,6 @@ class ImportExport extends React.Component {
               </List>
             </div>
           </Dialog>
-
       </div>
     )
   }

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -80,7 +80,7 @@ class OpenLayersMap extends React.Component {
     const { selectedTrail, trails } = this.props;
     const { map } = this.state;
     if (selectedTrail !== prevProps.selectedTrail && selectedTrail) {
-      const firstCoords = trails.getIn([selectedTrail, 'coords'])[0];
+      const firstCoords = trails.getIn([selectedTrail, 'feature']).getGeometry().getFirstCoordinate();
       if (firstCoords.length) {
         const centerCoords = Projection.fromLonLat(firstCoords);
         map.getView().animate({

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -53,8 +53,8 @@ class OpenLayersMap extends React.Component {
     if (selectedTrail) {
       const modifiable = new Collection([]);
       if (mode === 'trails') {
-        const feature = trails.getIn([selectedTrail, 'feature']);
-        modifiable.push(feature);
+        const features = trails.getIn([selectedTrail, 'features']);
+        _.each(features, f => modifiable.push(f));
       } else {
         hydrants.filter((h) => h.get('trail') === selectedTrail)
           .forEach((h) => modifiable.push(h.get('feature')));
@@ -80,7 +80,7 @@ class OpenLayersMap extends React.Component {
     const { selectedTrail, trails } = this.props;
     const { map } = this.state;
     if (selectedTrail !== prevProps.selectedTrail && selectedTrail) {
-      const firstCoords = trails.getIn([selectedTrail, 'feature']).getGeometry().getFirstCoordinate();
+      const firstCoords = trails.getIn([selectedTrail, 'features'])[0].getGeometry().getFirstCoordinate();
       if (firstCoords.length) {
         const centerCoords = Projection.fromLonLat(firstCoords);
         map.getView().animate({
@@ -143,13 +143,18 @@ class OpenLayersMap extends React.Component {
 
   syncFeatures(trails, hydrants) {
     const { source } = this.state;
-    if (source.getFeatures().length !== trails.size + hydrants.size) {
+    const totalFeatures = trails.reduce((features, t) => {
+      return features + t.get('features').length;
+    }, 0) + hydrants.size;
+    if (source.getFeatures().length !== totalFeatures) {
       // add new features if needed
       const newFeatures = [];
       trails.forEach((trail) => {
-        if (!source.getFeatureById(`t${trail.get('id')}`)) {
-          newFeatures.push(trail.get('feature'));
-        }
+        _.each(trail.get('features'), (feature) => {
+          if (!source.getFeatureById(feature.getId())) {
+            newFeatures.push(feature);
+          }
+        });
       });
       hydrants.forEach((hydrant) => {
         if (!source.getFeatureById(`h${hydrant.get('id')}`)) {
@@ -163,9 +168,13 @@ class OpenLayersMap extends React.Component {
       // remove deleted features if needed
       _.map(source.getFeatures(), (feature) => {
         const featureId = feature.getId();
-        if (featureId[0] === 't' && !trails.has(featureId.slice(1))) {
-          source.removeFeature(feature);
-        } else if (featureId[0] === 'h' && !hydrants.has(featureId.slice(1))) {
+        const [type, id, number] = featureId.split('-');
+        if (type === 't') {
+          if (!trails.has(id) || !_.find(trails.get(id).features, f => f.getId() === featureId)) {
+            source.removeFeature(feature);
+          }
+        }
+        else if (type === 'h' && !hydrants.has(id)) {
           source.removeFeature(feature);
         }
       });

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -80,13 +80,14 @@ class OpenLayersMap extends React.Component {
     const { selectedTrail, trails } = this.props;
     const { map } = this.state;
     if (selectedTrail !== prevProps.selectedTrail && selectedTrail) {
-      const firstCoords = trails.getIn([selectedTrail, 'features'])[0].getGeometry().getFirstCoordinate();
-      if (firstCoords.length) {
-        const centerCoords = Projection.fromLonLat(firstCoords);
+      try {
+        const firstCoords = trails.getIn([selectedTrail, 'features'])[0].getGeometry().getInteriorPoint().getCoordinates();
         map.getView().animate({
-          center: centerCoords,
+          center: firstCoords,
           duration: 500,
         });
+      } catch (err) {
+        console.log('No coordinates found for this trail');
       }
     }
   }
@@ -99,7 +100,7 @@ class OpenLayersMap extends React.Component {
       source: new BingMaps({
         hidpi: true,
         key: 'ApcR8_wnFxnsXwuY_W2mPQuMb-QB0Kg-My65RJYZL2g9fN6NCFA8-s0lsvxTTs2G',
-        imagerySet: 'AerialWithLabels',
+        imagerySet: 'Aerial',
       }),
     });
 

--- a/src/redux/reducers/HydrantReducer.js
+++ b/src/redux/reducers/HydrantReducer.js
@@ -31,7 +31,7 @@ export default (state = initialState, action) => {
       const { prevSelected, selected } = action.data;
       if (prevSelected) {
         state.hydrants
-          .filter(hydrant => hydrant.get('id') === prevSelected)
+          .filter(hydrant => hydrant.get('trail') === prevSelected)
           .forEach(hydrant => {
             const feature = hydrant.get('feature');
             feature.unset('selected');
@@ -40,7 +40,7 @@ export default (state = initialState, action) => {
       }
       if (selected) {
         state.hydrants
-          .filter(hydrant => hydrant.get('id') === selected)
+          .filter(hydrant => hydrant.get('trail') === selected)
           .forEach(hydrant => {
             const feature = hydrant.get('feature');
             feature.set('selected', true);

--- a/src/redux/reducers/TrailReducer.js
+++ b/src/redux/reducers/TrailReducer.js
@@ -30,14 +30,18 @@ export default (state = initialState, action) => {
       // but this map stuff is a little wack
       const { prevSelected, selected } = action.data;
       if (prevSelected && state.trails.get(prevSelected)) {
-        const feature = state.trails.getIn([prevSelected, 'feature']);
-        feature.unset('selected');
-        feature.changed();
+        const features = state.trails.getIn([prevSelected, 'features']);
+        _.each(features, (f) => {
+          f.unset('selected');
+          f.changed();
+        });
       }
       if (selected && state.trails.get(selected)) {
-        const feature = state.trails.getIn([selected, 'feature']);
-        feature.set('selected', true);
-        feature.changed();
+        const features = state.trails.getIn([selected, 'features']);
+        _.each(features, (f) => {
+          f.set('selected', true);
+          f.changed();
+        });
       }
       return state;
     }
@@ -67,9 +71,9 @@ export default (state = initialState, action) => {
       return {
         ...state,
         trails: state.trails.merge(trails),
-      }
+      };
     }
     default:
       return state;
   }
-}
+};

--- a/src/utils/mapUtils.js
+++ b/src/utils/mapUtils.js
@@ -7,8 +7,6 @@ import axios from 'axios';
 import _ from 'lodash';
 
 export function getMapStyle(feature, resolution) {
-  console.log("tears");
-  console.log(feature.getGeometry().getType());
   if (feature.getGeometry().getType() === 'Point') {
     // hydrant styling defaults
     const fill = new Fill({ color: 'rgba(222, 49, 33, 0.4)' });
@@ -40,8 +38,7 @@ export function getMapStyle(feature, resolution) {
       }),
       text,
     });
-  } else if (feature.getGeometry().getType() === 'MultiPolygon' || feature.getGeometry().getType() === 'Polygon') {
-    console.log("here");
+  } else if (feature.getGeometry().getType() === 'Polygon') {
     // trail styling defaults
     const text = new Text({
       overflow: true,

--- a/src/utils/mapUtils.js
+++ b/src/utils/mapUtils.js
@@ -7,7 +7,8 @@ import axios from 'axios';
 import _ from 'lodash';
 
 export function getMapStyle(feature, resolution) {
-
+  console.log("tears");
+  console.log(feature.getGeometry().getType());
   if (feature.getGeometry().getType() === 'Point') {
     // hydrant styling defaults
     const fill = new Fill({ color: 'rgba(222, 49, 33, 0.4)' });
@@ -39,7 +40,8 @@ export function getMapStyle(feature, resolution) {
       }),
       text,
     });
-  } else if (feature.getGeometry().getType() === 'Polygon') {
+  } else if (feature.getGeometry().getType() === 'MultiPolygon' || feature.getGeometry().getType() === 'Polygon') {
+    console.log("here");
     // trail styling defaults
     const text = new Text({
       overflow: true,

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -1,9 +1,9 @@
-import { Record } from 'immutable';
+import { Record, List } from 'immutable';
 
 export const Trail = Record({
   id: null,
   name: null,
-  feature: null,
+  features: [],
 });
 
 export const Hydrant = Record({

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -3,7 +3,6 @@ import { Record } from 'immutable';
 export const Trail = Record({
   id: null,
   name: null,
-  coords: [],
   feature: null,
 });
 


### PR DESCRIPTION
Get trails with multiple polygons working. This won't actually work for drawing yet, but imports are all good now. I'll handle drawing/modifying in a separate PR later this afternoon. I'm gonna make the switch to remove modes as part of that, per our discussion earlier, so felt I should break this up. 

- Trails now have `features` array attribute instead of `feature` attribute. 
- I removed `coords` as an attribute on the trails object. We weren't using outside the map anyways, so don't need it. 
- I changed the ID's a bit to get them working. Now the feature ID is `type-id-number` where type is `t` or `h` and `id` is the id of that type, so lookups should be easier. The number at the end is just to ensure uniqueness since trails can have multiple features now, it's the index from the import. 

I don't think there's anything too surprising in here, it's pretty much just using a bunch of `_.each(features, ...`'s to replace each look at `feature` previously, and likewise. The usual linter fixes scattered around make more lines look changed. But I think we're slowly approaching linter compliance, so hopefully less of these in the future. 