### PR TITLE
Map min resolution

### DIFF
--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -39,25 +39,36 @@ class OpenLayersMap extends React.Component {
   componentDidUpdate(prevProps) {
     const { selectedTrail, trails, interaction, hydrants } = this.props;
     const { map } = this.state;
-    
+
     // update interactions
     if (
-      interaction !== prevProps.interaction || 
-      selectedTrail !== prevProps.selectedTrail || 
-      hydrants.size !== prevProps.hydrants.size || 
-      (selectedTrail === prevProps.selectedTrail && 
+      interaction !== prevProps.interaction ||
+      selectedTrail !== prevProps.selectedTrail ||
+      hydrants.size !== prevProps.hydrants.size ||
+      (selectedTrail === prevProps.selectedTrail &&
         trails.getIn([selectedTrail, 'features'], []).length !== prevProps.trails.getIn([selectedTrail, 'features'], []).length)) {
       this.updateInteractions();
     }
 
     // pan to new selectedTrail
     if (selectedTrail !== prevProps.selectedTrail && selectedTrail) {
+
       try {
-        const firstCoords = trails.getIn([selectedTrail, 'features'])[0].getGeometry().getInteriorPoint().getCoordinates();
+        const firstTrailGeom = trails.getIn([selectedTrail, 'features'])[0].getGeometry()
+        const geomExtent = firstTrailGeom.getExtent()
+        const view = map.getView()
+        const zoomResolution = view.getResolutionForExtent(geomExtent)
+        const zoomLevel = view.getZoomForResolution(zoomResolution)
+
+        const firstCoords = firstTrailGeom.getInteriorPoint().getCoordinates();
         map.getView().animate({
           center: firstCoords,
           duration: 500,
+          zoom: zoomLevel,
         });
+        // Instead of Panning the below code will jerk to the trail
+        // and will fit the trail but is not as smooth.
+        // map.getView().fit(firstTrailGeom, map.getSize());
       } catch (err) {
         console.log('No coordinates found for this trail');
       }

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -88,8 +88,7 @@ class OpenLayersMap extends React.Component {
         key: 'ApcR8_wnFxnsXwuY_W2mPQuMb-QB0Kg-My65RJYZL2g9fN6NCFA8-s0lsvxTTs2G',
         imagerySet: 'Aerial',
         maxZoom: 19,
-      }),
-      minResolution: .2,
+      })
     });
 
 
@@ -104,13 +103,6 @@ class OpenLayersMap extends React.Component {
 
     geocoder.setTarget(document.getElementById('searchLocations'));*/
 
-    const OSMLayer = new TileLayer({
-      source: new OSM(),
-      maxResolution: .2,
-    })
-
-
-
     const resortLayer = new LayerVector({
       source,
       style: getMapStyle,
@@ -124,7 +116,7 @@ class OpenLayersMap extends React.Component {
     const map = new Map({
       loadTilesWhileInteracting: false,
       target: 'map-container',
-      layers: [OSMLayer, bingMapsLayer, resortLayer],
+      layers: [bingMapsLayer, resortLayer],
       view: new View({
         projection,
         center: Projection.fromLonLat(centerCoords),

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -13,6 +13,7 @@ import Modify from 'ol/interaction/modify';
 import Snap from 'ol/interaction/snap';
 //import Geocoder from 'ol-geocoder';
 import { getMapStyle } from '../utils/mapUtils';
+import OSM from 'ol/source/osm';
 
 class OpenLayersMap extends React.Component {
   constructor(props) {
@@ -78,15 +79,20 @@ class OpenLayersMap extends React.Component {
   setupMap() {
     const { source } = this.state;
     const { hydrantSelected } = this.props;
+
     const bingMapsLayer = new TileLayer({
       visible: true,
       preload: Infinity,
       source: new BingMaps({
-        hidpi: true,
+        hidpi: false,
         key: 'ApcR8_wnFxnsXwuY_W2mPQuMb-QB0Kg-My65RJYZL2g9fN6NCFA8-s0lsvxTTs2G',
         imagerySet: 'Aerial',
+        maxZoom: 19,
       }),
+      minResolution: .2,
     });
+
+
     /*const geocoder = new Geocoder('nominatim', {
       provider: 'osm',
       lang: 'en',
@@ -97,6 +103,13 @@ class OpenLayersMap extends React.Component {
     });
 
     geocoder.setTarget(document.getElementById('searchLocations'));*/
+
+    const OSMLayer = new TileLayer({
+      source: new OSM(),
+      maxResolution: .2,
+    })
+
+
 
     const resortLayer = new LayerVector({
       source,
@@ -111,7 +124,7 @@ class OpenLayersMap extends React.Component {
     const map = new Map({
       loadTilesWhileInteracting: false,
       target: 'map-container',
-      layers: [bingMapsLayer, resortLayer],
+      layers: [OSMLayer, bingMapsLayer, resortLayer],
       view: new View({
         projection,
         center: Projection.fromLonLat(centerCoords),


### PR DESCRIPTION
When map is zoomed in past max zoom level, prevent tiles from loading. Also loads a different layer (OSM) past a low resolution to give user more valuable information than a low res tile rendering.