### PR TITLE
one modify event per feature is way better

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,9 +21,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link href="https://unpkg.com/ol-geocoder/dist/ol-geocoder.min.css" rel="stylesheet">
-    <script src="https://unpkg.com/ol-geocoder"></script>
-
     <title>Snomatic v2 Demo</title>
   </head>
   <body>

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -57,7 +57,8 @@ class Container extends React.Component {
     addTrail(trail);
   }
 
-  drawEnd(feature) {
+  drawEnd(e) {
+    const { feature } = e;
     const { interaction, selectedTrail, trails, addTrail, addHydrant, modifyTrail } = this.props;
     if (interaction === 'DRAW_MODIFY_TRAIL') {
       const trail = trails.get(selectedTrail);
@@ -82,8 +83,10 @@ class Container extends React.Component {
       let id = new Date().getTime();
       id = id.toString();
       const newHydrant = new Hydrant({
-        id, name,
-        coords, feature,
+        id,
+        name,
+        coords,
+        feature,
         trail: selectedTrail,
       });
       feature.setId(`h-${id}-0`);
@@ -96,13 +99,12 @@ class Container extends React.Component {
 
   modifyEnd(e) {
     const { interaction, modifyHydrant } = this.props;
-    const features = e.features;
-    if (interaction === 'DRAW_MODIFY_HYDRANTS') {
-      const feature = _.find(features.getArray(), f => f.getId() && f.getId()[0] === 'h');
+    const { features } = e;
+    if (interaction === 'DRAW_MODIFY_HYDRANTS' && features.item(0)) {
+      const feature = features.item(0);
       const hydrantId = feature.getId().split('-')[1];
       const mapCoords = feature.getGeometry().getCoordinates();
       const coords = Projection.toLonLat(mapCoords);
-      // do a projection and save them with modifyHyrant
       modifyHydrant(hydrantId, { coords });
     }
   }

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -11,7 +11,7 @@ import SourceVector from 'ol/source/vector';
 import Draw from 'ol/interaction/draw';
 import Modify from 'ol/interaction/modify';
 import Snap from 'ol/interaction/snap';
-//import Geocoder from 'ol-geocoder';
+import Geocoder from 'ol-geocoder';
 import { getMapStyle } from '../utils/mapUtils';
 
 class OpenLayersMap extends React.Component {
@@ -87,7 +87,7 @@ class OpenLayersMap extends React.Component {
         imagerySet: 'Aerial',
       }),
     });
-    /*const geocoder = new Geocoder('nominatim', {
+    const geocoder = new Geocoder('nominatim', {
       provider: 'osm',
       lang: 'en',
       placeholder: 'Search for ...',
@@ -96,7 +96,7 @@ class OpenLayersMap extends React.Component {
       autoComplete: true,
     });
 
-    geocoder.setTarget(document.getElementById('searchLocations'));*/
+    geocoder.setTarget(document.getElementById('searchLocations'));
 
     const resortLayer = new LayerVector({
       source,
@@ -120,7 +120,7 @@ class OpenLayersMap extends React.Component {
     });
 
     // Controls
-    // map.addControl(geocoder);
+    map.addControl(geocoder);
     map.on('click', this.onMapClick);
     this.setState({ map });
   }
@@ -129,7 +129,7 @@ class OpenLayersMap extends React.Component {
     const {
       trails, hydrants,
       selectedTrail, interaction,
-      modifyEnd,
+      modifyEnd, drawEnd
     } = this.props;
     const { source, map, mapInteractions } = this.state;
     _.each(mapInteractions, i => map.removeInteraction(i));
@@ -137,7 +137,7 @@ class OpenLayersMap extends React.Component {
     const newInteractions = [];
     // create new draw or modify interactions
     let type = null;
-    const modifiable = new Collection([]);
+    const modifiable = [];
     if (interaction === 'DRAW_MODIFY_TRAIL' && selectedTrail) {
       type = 'Polygon';
       _.each(trails.getIn([selectedTrail, 'features']), f => modifiable.push(f));
@@ -150,14 +150,15 @@ class OpenLayersMap extends React.Component {
       const draw = new Draw({
         source, type, geometryName: type,
       });
-      draw.on('drawend', this.drawEnd);
+      draw.on('drawend', drawEnd);
       newInteractions.push(draw);
     }
-    if (modifiable.getLength()) {
-      const modify = new Modify({ features: modifiable });
-      modify.on('modifyend', modifyEnd);
-      modify.on('modifystart', this.modifyStart);
-      newInteractions.push(modify);
+    if (modifiable.length) {
+      _.each(modifiable, (m) => {
+        const modify = new Modify({ features: new Collection([m]) });
+        modify.on('modifyend', modifyEnd);
+        newInteractions.push(modify);
+      });
     }
 
     if (interaction === 'DRAW_MODIFY_TRAIL') {
@@ -170,54 +171,6 @@ class OpenLayersMap extends React.Component {
 
     _.each(newInteractions, i => map.addInteraction(i));
     this.setState({ mapInteractions: newInteractions });
-  }
-
-  drawEnd = (e) => {
-    const { drawEnd, interaction, hydrantSelected } = this.props;
-    const { map } = this.state;
-    if (interaction === 'DRAW_MODIFY_HYDRANTS') {
-      const coords = e.feature.getGeometry().getCoordinates();
-      const pixel = map.getPixelFromCoordinate(coords);
-      const features = map.getFeaturesAtPixel(pixel);
-      if (features) {
-        const match = _.reduce(features, (curr, f) => {
-          if (curr) {
-            return curr;
-          } else {
-            const featureId = f.getId() || '';
-            const [type, hydrantId, number] = featureId.split('-');
-            return type === 'h' ? hydrantId : curr;
-          }
-        }, null);
-        if (match) {
-          return;
-        }
-      }
-    }
-    return drawEnd(e.feature);
-  }
-
-  modifyStart = (e) => {
-    const { interaction, hydrantSelected } = this.props;
-    const { map } = this.state;
-    if (interaction === 'DRAW_MODIFY_HYDRANTS') {
-      const pixel = e.target.lastPixel_;
-      const features = map.getFeaturesAtPixel(pixel);
-      if (features) {
-        const match = _.reduce(features, (curr, f) => {
-          if (curr) {
-            return curr;
-          } else {
-            const featureId = f.getId() || '';
-            const [type, hydrantId, number] = featureId.split('-');
-            return type === 'h' ? hydrantId : curr;
-          }
-        }, null);
-        if (match) {
-          hydrantSelected(match);
-        }
-      }
-    }
   }
 
   onMapClick = (e) => {

--- a/src/redux/reducers/HydrantReducer.js
+++ b/src/redux/reducers/HydrantReducer.js
@@ -33,7 +33,7 @@ export default (state = initialState, action) => {
       const hydrantId = action.data.selected;
       return {
         ...state,
-        hydrants: state.hydrants.delete(hydrantId)
+        hydrants: state.hydrants.delete(hydrantId),
       };
     }
     case HYDRANT_MODIFIED: {
@@ -42,7 +42,6 @@ export default (state = initialState, action) => {
         .withMutations((h) => {
           _.each(editedFields, (val, key) => h.set(key, val));
         });
-      // console.log(newHydrant.toJS())
       newHydrant.get('feature').setProperties(editedFields);
       if (editedFields.coords) {
         newHydrant.get('feature').getGeometry().setCoordinates(Projection.fromLonLat(editedFields.coords));

--- a/src/redux/reducers/SelectedHydrantReducer.js
+++ b/src/redux/reducers/SelectedHydrantReducer.js
@@ -5,6 +5,7 @@ const {
   HYDRANT_DELETED,
   HYDRANT_ADDED,
   TRAIL_SELECTED,
+  HYDRANT_MODIFIED,
 } = ActionTypes;
 
 const initialState = null;
@@ -23,6 +24,8 @@ export default (state = initialState, action) => {
       }
       return state;
     }
+    case HYDRANT_MODIFIED:
+      return action.data.id;
     default:
       return state;
   }

--- a/src/redux/reducers/SelectedTrailReducer.js
+++ b/src/redux/reducers/SelectedTrailReducer.js
@@ -3,6 +3,7 @@ import ActionTypes from '../ActionTypes';
 const {
   TRAIL_SELECTED,
   TRAIL_DELETED,
+  TRAIL_ADDED,
 } = ActionTypes;
 
 const initialState = null;
@@ -19,6 +20,8 @@ export default (state = initialState, action) => {
       }
       return state;
     }
+    case TRAIL_ADDED:
+      return action.data.get('id');
     default:
       return state;
   }


### PR DESCRIPTION
Making a separate modify interaction per modifiable object is way better than putting in a Collection; I kept messing up trying to figure which feature in the modifyend was actually modified, so this gets rid of that, and we're never making SO many modifiable objects at a time where I think there's much overhead, maybe a few dozen max. 

This makes the click events and handling modifies much easier and took me too long to realize. Also added a couple bits to make selection of trails and hydrants more seamless and expected (creating a trail selects it, modifying a hydrant selects it). 

Put the geocoder back in, and will work on getting it to minify properly for the build next. 