### PR TITLE
limit number of rendered selects

### DIFF
--- a/src/components/ManualAssociateHydrantsForm.js
+++ b/src/components/ManualAssociateHydrantsForm.js
@@ -61,7 +61,7 @@ class ManualAssociateHydrantsForm extends React.Component {
   renderHydrantItem = (hydrant, index, trailMenuItems) => {
     return (
       <div key={index} onMouseEnter={() => this.hydrantHovered(hydrant.get('id'))}>
-        <span style={{ width: '100px' }}>{index}</span>
+        <span style={{ width: '100px' }}>{index + 1}</span>
         <Select
           onChange={e => this.updateManualTrailAssociation(hydrant.get('id'), e.target.value)}
           value={hydrant.get('trail')}
@@ -93,13 +93,20 @@ class ManualAssociateHydrantsForm extends React.Component {
         return <MenuItem key={id} value={id}>{trail.get('name')}</MenuItem>;
       });
 
+    const limit_to = 20;
+
     return (
       <div>
         <h4>Confirm hydrant trails</h4>
         <Button onClick={this.endManualAssignment}>Back to Menu</Button>
         {hydrants
           .valueSeq()
+          .take(limit_to)
           .map((h, i) => this.renderHydrantItem(h, i, trailMenuItems))
+        }
+        {hydrants.size > limit_to ? (
+          <p>...and {hydrants.size - limit_to} others</p>
+          ) : null
         }
         <Button onClick={() => {dataImported({ hydrants }); this.endManualAssignment();}}>
           Confirm all hydrant assignments

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -69,7 +69,6 @@ class OpenLayersMap extends React.Component {
       map.getView().animate({
         center: coords,
         duration: 0,
-        zoom: 17,
       });
     }
   }


### PR DESCRIPTION
Limiting the number of hydrant select's to 20 at a time fixes the lagginess I mentioned before, it was just slow trying to render 200+ hydrants each with 50 or so trails for selects, and re-doing that each time a new one was hovered was a little too much. 

Also took out the auto-zoom for hydrants, I don't think that was helping, it'll still center the map on them though. 

And we'll start number them from 1 instead of 0 because that's prettier for users. 