### PR TITLE
new geocoder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
 	"extends": "airbnb",
 	"rules": {
 		"react/jsx-filename-extension": 0,
-		"react/prefer-stateless-function": [0, {}]
+		"react/prefer-stateless-function": 0
 	},
 	"parser": "babel-eslint"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lodash": "^4.17.5",
     "material-ui": "^1.0.0-beta.38",
     "ol": "^4.6.5",
-    "ol-geocoder": "^3.1.0",
     "rc-slider": "^8.6.1",
     "react": "^16.2.0",
     "react-bootstrap": "^0.32.1",
@@ -20,6 +19,7 @@
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",
     "react-scripts": "1.1.1",
+    "react-select": "^1.2.1",
     "redux": "^3.7.2",
     "typeface-roboto": "0.0.54"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -29,10 +29,6 @@
   top: 4.875em;
 }
 
-.ol-geocoder{
-  position: unset !important;
-}
-
 .gcd-gl-btn{
   height:2em !important;
   width: 2em !important;
@@ -55,4 +51,5 @@
   position: absolute;
   right: 4em;
   top: 1em;
+  width: 250px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'typeface-roboto';
-import 'ol-geocoder/dist/ol-geocoder.css';
+import 'react-select/dist/react-select.css';
 
 import './App.css';
 import Container from './components/Container';

--- a/src/components/Geocoder.js
+++ b/src/components/Geocoder.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import _ from 'lodash';
+import axios from 'axios';
+import ReactDOM from 'react-dom';
+import { Async } from 'react-select';
+
+const params = {
+  format: 'json',
+  addressdetails: 1,
+  limit: 10,
+  countrycodes: '',
+  'accept-language': 'en-us',
+};
+
+class Geocoder extends React.Component {
+  debouncedGetOptions = _.debounce((input, callback) => {
+    params.q = input;
+    axios.get('https://nominatim.openstreetmap.org/search/', { params })
+      .then(resp => callback(null, {
+        options: _.map(resp.data, (d) => {
+          return {
+            value: `${d.lon},${d.lat}`,
+            label: d.display_name,
+          };
+        }),
+      })
+    );
+  }, 250);
+
+  handleChange = (option) => {
+    const { locationSelected } = this.props;
+    const coords = _.map(option.value.split(','), (p) => parseFloat((p)));
+    locationSelected(coords);
+  }
+
+  render() {
+    return (
+      <Async
+        loadOptions={this.debouncedGetOptions}
+        onChange={this.handleChange}
+      />
+    );
+  }
+}
+
+function createGeocoder(id, onSelect) {
+  ReactDOM.render(
+    <Geocoder locationSelected={onSelect} />,
+    document.getElementById(id),
+  );
+}
+
+export default createGeocoder;

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -12,7 +12,7 @@ import SourceVector from 'ol/source/vector';
 import Draw from 'ol/interaction/draw';
 import Modify from 'ol/interaction/modify';
 import Snap from 'ol/interaction/snap';
-// import Geocoder from 'ol-geocoder';
+import createGeocoder from './Geocoder';
 import { getMapStyle } from '../utils/mapUtils';
 import RotationSlider from './RotationSlider';
 import extent from 'ol/extent';
@@ -124,16 +124,6 @@ class OpenLayersMap extends React.Component {
         maxZoom: 19,
       }),
     });
-    // const geocoder = new Geocoder('nominatim', {
-    //   provider: 'osm',
-    //   lang: 'en',
-    //   placeholder: 'Search for ...',
-    //   limit: 5,
-    //   keepOpen: true,
-    //   autoComplete: true,
-    // });
-    //
-    // geocoder.setTarget(document.getElementById('searchLocations'));
 
     const resortLayer = new LayerVector({
       source,
@@ -153,12 +143,20 @@ class OpenLayersMap extends React.Component {
         projection,
         center: Projection.fromLonLat(centerCoords),
         zoom: 14.2,
-        rotation: this.state.rotation
+        rotation: this.state.rotation,
       }),
     });
 
     // Controls
-    // map.addControl(geocoder);
+    const onGeocoderChange = (coords) => {
+      const mapCoords = Projection.fromLonLat(coords);
+      map.getView().animate({
+        center: mapCoords,
+        duration: 100,
+      });
+    };
+    createGeocoder('searchLocations', onGeocoderChange);
+
     map.on('click', this.onMapClick);
     this.setState({ map });
   }
@@ -166,8 +164,8 @@ class OpenLayersMap extends React.Component {
   updateInteractions(nextProps) {
     const {
       trails, hydrants,
-      interaction,modifyEnd,
-      drawEnd, editableTrail
+      interaction, modifyEnd,
+      drawEnd, editableTrail,
     } = nextProps;
     const { source, map, mapInteractions } = this.state;
     _.each(mapInteractions, i => map.removeInteraction(i));


### PR DESCRIPTION
Doing another `reactDOM.render` probably isn't best practice to add the geocoder this way, but I didn't want to clutter up the container any more for now, and this keeps it all in the map component, which is convenient since nowhere else cares about this component. 