### PR TITLE
Make getElevations component independent

### DIFF
--- a/src/components/AutoAssociate.js
+++ b/src/components/AutoAssociate.js
@@ -17,14 +17,6 @@ class AutoAssociate extends React.Component {
     };
   }
 
-  getElevations = () => {
-    const { dataImported, hydrants } = this.props;
-    const onFetchSuccess = (newHydrants) => {
-      dataImported({ hydrants: newHydrants });
-    };
-    getElevations(hydrants, onFetchSuccess);
-  }
-
   assignHydrants = () => {
     const { dataImported, hydrants, trails, manualAssignmentItemsAdded } = this.props;
     const orphans = hydrants.filter(h => h.get('trail') === null);
@@ -42,7 +34,7 @@ class AutoAssociate extends React.Component {
 
   openDialog = () => {
     this.assignHydrants();
-    setTimeout(this.getElevations, 20);
+    setTimeout(getElevations, 20);
     this.setState({ dialogOpen: true });
   }
 

--- a/src/redux/reducers/HydrantReducer.js
+++ b/src/redux/reducers/HydrantReducer.js
@@ -55,6 +55,9 @@ export default (state = initialState, action) => {
       const { id, editedFields } = action.data;
       const newHydrant = state.hydrants.get(id).withMutations((h) => {
         _.each(editedFields, (val, key) => h.set(key, val));
+        if (editedFields.coords && !editedFields.elevation) {
+          h.set('elevation', null);
+        }
       });
       updateHydrantFeatures(newHydrant, editedFields);
       return {

--- a/src/utils/bulkUpdateUtils.js
+++ b/src/utils/bulkUpdateUtils.js
@@ -15,12 +15,14 @@ export function getElevations() {
     const coords = _.map(needsElevation, h => _.clone(h.get('coords')).reverse());
     mapquestApi.fetchElevationForCoords(coords)
       .then((resp) => {
-        const updatedHydrants = _.map(needsElevation, (h, index) => {
+        const updatedHydrants = _.filter(_.map(needsElevation, (h, index) => {
           return h.set('elevation', resp[index].elevation);
-        });
+        }), h => h.get('elevation'));
         // return to immutable dictionary object and pass to the handler
-        const updatedHydrantsMap = Immutable.Map(_.keyBy(updatedHydrants, h => h.get('id')));
-        store.dispatch({ type: DATA_IMPORTED, data: { hydrants: updatedHydrantsMap } });
+        if (updatedHydrants.length) {
+          const updatedHydrantsMap = Immutable.Map(_.keyBy(updatedHydrants, h => h.get('id')));
+          store.dispatch({ type: DATA_IMPORTED, data: { hydrants: updatedHydrantsMap } });
+        }
       });
   }
 }


### PR DESCRIPTION
Now you can just import the function and call it whenever you want to without passing in anything (state, store, etc), like whenever a new TrailForm is loaded, or every time a hydrant is dropped even if we want to. See the `AutoAssociate` example. 

As Scott pointed out, maybe better to move renaming functions to a different section from AutoAssociate, or at least rename that button to be clearer. 

Only caveat is not to always DEPEND on hydrants having an elevation after this. The API call could fail to get elevation for some reason; each call of this function will still do another fetch for those failing hydrants, but won't update state since nothing is actually updating. 