### PR TITLE
Fixes

### DIFF
--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -238,9 +238,6 @@ class ImportExport extends React.Component {
         .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
         .value();
 
-
-        console.log(trailHydrants)
-
       for (let i = 0; i < 100; i += 1) {
         let hydId = i + 1
         let elevation = 0

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -178,14 +178,18 @@ class ImportExport extends React.Component {
     const trailFeatures = []
     const hydrantFeatures = []
 
-    trails.valueSeq().forEach((v) => {
+    trails
+      .sortBy((a) => a.get('name'))
+      .valueSeq()
+      .forEach((v, trailIndex) => {
+
       let trailName = v.get('name').split(' ').join('_')
       // Iterate through Trail's Features
-      v.get('features').forEach((f) => {
+      v.get('features').forEach((f, fIndex) => {
         if (f.get('originalTrailName')) {
           trailName = f.get('originalTrailName')
         }
-        const description = trailName
+        const description = `${trailName},${trailIndex + fIndex + 1}`
         f.unset('features')
         f.set('description', description)
         f.setStyle(getMapStyle)
@@ -195,7 +199,7 @@ class ImportExport extends React.Component {
       _.chain(hydrants.toJS())
         .values()
         .filter({ trail: v.get('id') })
-        .orderBy('name', 'asc')
+        .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
         .value()
         .forEach((h, index) => {
            const feature = h.feature

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -229,24 +229,27 @@ class ImportExport extends React.Component {
     ]
     trails.keySeq().forEach((trailId) => {
       const trail = trails.get(trailId)
-      const trailName = trail.get('features')[0].get('originalTrailName') || trail.get('name').split(' ').join('_')
+      const trailName = trail.get('features') ? trail.get('features')[0].get('originalTrailName') : trail.get('name').split(' ').join('_')
 
       const trailHydrants = _
         .chain(hydrants.toJS())
         .values()
         .filter({ trail: trailId })
-        .orderBy('name', 'asc')
+        .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
         .value();
 
+
+        console.log(trailHydrants)
+
       for (let i = 0; i < 100; i += 1) {
-        let hydId = i
+        let hydId = i + 1
         let elevation = 0
         if (trailHydrants[i]) {
           hydId = trailHydrants[i].name
           elevation = trailHydrants[i].elevation
         }
         hydrantsRows.push([
-          trailName, i, hydId, 0, 0,
+          trailName, i + 1, hydId, 0, 0,
           'None', 0, 'None', elevation, 0,
           0, 0, 'None',
         ]);


### PR DESCRIPTION
Addresses Issues noted in Lances email: 

CSV export:
1.)    The Hyd_Index column is starting at 0 and should start at 1.
2.)    The Hyd_ID column order goes out of sequence if you are using just numbers with no alpha characters. It’s the old Excel 10 before 2 issue when the numbers are treated like text. It’s easy enough to just resort the column in Excel but didn’t know if you wanted to try and tweak that?
 
Trail export:
1.)    Works well but if possible can we add an index to the description feature like the hydrants? They would be indexed in alphabetical order so for example it would look like ATrail, 1 then BTrail,2 the CTrail, 3…you get the idea.

 