### PR TITLE
Scotts edits1

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -48,7 +48,8 @@ const {
   MANUAL_ASSIGNMENT_OPENED,
   MANUAL_ASSIGNMENT_CLOSED,
   MANUAL_ASSIGNMENT_HYDRANT_FOCUSED,
-  UPDATE_MANUAL_TRAIL_ASSOCIATION
+  UPDATE_MANUAL_TRAIL_ASSOCIATION,
+  ORPHANS_SELECTED,
 } = ActionTypes;
 
 
@@ -61,8 +62,17 @@ class Container extends React.Component {
     this.state = {
       drawerOpen: false,
       message: null,
-      importExportOpen: false
+      importExportOpen: false,
+      orphanRowSelected: false,
     };
+  }
+
+  toggleOrphanSelect = () => {
+    const {orphansSelected } = this.props
+    this.setState({
+      orphanRowSelected: !this.state.orphanRowSelected
+    })
+    orphansSelected(!this.state.orphanRowSelected)
   }
 
   setMessageToNull = () => {
@@ -92,7 +102,6 @@ class Container extends React.Component {
       drawerOpen: true
     });
   }
-
 
   drawEnd(e) {
     const { feature } = e;
@@ -161,12 +170,14 @@ class Container extends React.Component {
       hydrantSelected, closeManualAssignment,
       manualAssignmentItems, focusedHydrant,
       focusHydrant, manualAssignmentOpen, trailDeleted, manualAssignmentItemsAdded,
-      openManualAssignment
+      openManualAssignment,
     } = this.props;
+
+    const {orphanRowSelected} = this.state;
 
     const orphanCount = hydrants.filter((h) => h.get('trail') === null).size;
 
-
+    //Displays the Assignment Forms
     if (manualAssignmentOpen) {
       return (
         <ManualAssociateHydrantsForm
@@ -179,7 +190,7 @@ class Container extends React.Component {
         />
       );
     }
-
+    //Displays The Edit Form For a Given Trail
     if (editableTrail) {
       return (
         <TrailForm
@@ -196,7 +207,7 @@ class Container extends React.Component {
         />
       )
     }
-
+    // Displays Intro Card If Nothing has Been Added
     if (trails.size === 0 && orphanCount === 0) {
       return (
 
@@ -231,9 +242,12 @@ class Container extends React.Component {
 
     }
 
+    //Displays the Default Trail List.
     return (
       <div>
         <TrailList
+          orphanRowSelected={orphanRowSelected}
+          toggleOrphanSelect={this.toggleOrphanSelect}
           dataImported={dataImported}
           manualAssignmentItemsAdded={manualAssignmentItemsAdded}
           openManualAssignment={openManualAssignment}
@@ -478,6 +492,9 @@ const mapDispatchToProps = dispatch => ({
   trailDeleted: id => dispatch({
     type: TRAIL_DELETED, data: id
   }),
+  orphansSelected: bool => dispatch({
+    type: ORPHANS_SELECTED, data: bool
+  })
 });
 
 export default compose(

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -106,7 +106,7 @@ class ImportExport extends React.Component {
      }
 
       const originalTrailName = name
-      trailName = _.words(trailName).join(' ');  
+      trailName = _.words(trailName).join(' ');
       const trailObj = trails.find(t => t.get('name') === trailName);
       const trailId = trailObj ? trailObj.get('id') : null;
       const geometry = feature.getGeometry().getType() === 'Point' ?

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -221,7 +221,6 @@ class ImportExport extends React.Component {
         })
         .value()
         .forEach((h, index) => {
-          console.log(h.name)
            const feature = h.feature
            feature.set('description', `${trailName},${index + 1},${feature.get('name')}`)
            feature.unset('selected')

--- a/src/components/ImportExport.js
+++ b/src/components/ImportExport.js
@@ -120,6 +120,7 @@ class ImportExport extends React.Component {
       feature.setStyle(getMapStyle);
       return new Hydrant({ id, name, coords, feature, trail: trailId });
     }
+
     const reader = new FileReader();
     reader.onload = (event) => {
       try {
@@ -145,7 +146,12 @@ class ImportExport extends React.Component {
             }
           } else {
             const hydrant = processHydrant(feature, index);
-            newHydrants[hydrant.get('id')] = hydrant;
+
+            //Only Allow Hydrants With ids
+            if(hydrant.get('id')){
+              newHydrants[hydrant.get('id')] = hydrant;
+            }
+
           }
         });
 
@@ -208,9 +214,14 @@ class ImportExport extends React.Component {
       _.chain(hydrants.toJS())
         .values()
         .filter({ trail: v.get('id') })
-        .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+        .sort((a, b) => {
+          if(a.name && b.name) {
+            return a.name.localeCompare(b.name, undefined, { numeric: true })
+          }
+        })
         .value()
         .forEach((h, index) => {
+          console.log(h.name)
            const feature = h.feature
            feature.set('description', `${trailName},${index + 1},${feature.get('name')}`)
            feature.unset('selected')
@@ -249,12 +260,19 @@ class ImportExport extends React.Component {
         trailName = trail.get('features')[0].get('originalTrailName') ? trail.get('features')[0].get('originalTrailName') : trailName
       }
 
+      const testHydrants = hydrants.toJS()
+
       const trailHydrants = _
         .chain(hydrants.toJS())
         .values()
         .filter({ trail: trailId })
-        .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+        .sort((a, b) => {
+          if(a.name && b.name) {
+            return a.name.localeCompare(b.name, undefined, { numeric: true })
+          }
+        })
         .value();
+
 
       for (let i = 0; i < 100; i += 1) {
         let hydId = i + 1

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -42,7 +42,6 @@ class OpenLayersMap extends React.Component {
   escapeInteractions = ()=> {
     const {map, mapInteractions } = this.state;
     _.each(mapInteractions, i => map.removeInteraction(i))
-    console.log(mapInteractions)
     this.setState({ mapInteractions: []})
   }
 
@@ -67,9 +66,6 @@ class OpenLayersMap extends React.Component {
 
     };
   }
-
-
-
 
   componentWillReceiveProps(nextProps) {
     const { trails, hydrants } = nextProps;

--- a/src/components/OpenLayersMap.js
+++ b/src/components/OpenLayersMap.js
@@ -17,6 +17,7 @@ import { getMapStyle } from '../utils/mapUtils';
 import RotationSlider from './RotationSlider';
 import extent from 'ol/extent';
 
+
 class OpenLayersMap extends React.Component {
   constructor(props) {
     super(props);
@@ -29,9 +30,46 @@ class OpenLayersMap extends React.Component {
     };
   }
 
+  deleteLastLine = ()=> {
+    const {mapInteractions, map } = this.state;
+    _.each(mapInteractions, i => {
+      if(i.geometryName_ === 'Polygon'){
+        i.removeLastPoint()
+      }
+    })
+  }
+
+  escapeInteractions = ()=> {
+    const {map, mapInteractions } = this.state;
+    _.each(mapInteractions, i => map.removeInteraction(i))
+    console.log(mapInteractions)
+    this.setState({ mapInteractions: []})
+  }
+
   componentDidMount() {
     this.setupMap();
+
+    const triggerEscape = ()=> {
+      this.escapeInteractions()
+    }
+    const triggerDeleteLast = ()=> {
+      this.deleteLastLine()
+    }
+    document.onkeydown = function(evt) {
+        evt = evt || window.event;
+        if (evt.keyCode == 27) {
+          triggerEscape()
+        }
+
+        if (evt.keyCode == 8){
+          triggerDeleteLast()
+        }
+
+    };
   }
+
+
+
 
   componentWillReceiveProps(nextProps) {
     const { trails, hydrants } = nextProps;
@@ -108,6 +146,8 @@ class OpenLayersMap extends React.Component {
     }
   }
 
+
+
   setupMap() {
     const { source } = this.state;
     const { hydrantSelected } = this.props;
@@ -157,6 +197,7 @@ class OpenLayersMap extends React.Component {
 
     map.on('click', this.onMapClick);
     this.setState({ map });
+
   }
 
   updateInteractions(nextProps) {

--- a/src/components/TrailForm.js
+++ b/src/components/TrailForm.js
@@ -11,6 +11,7 @@ import { FormControl, FormHelperText } from 'material-ui/Form';
 import _ from 'lodash';
 import Input, { InputLabel } from 'material-ui/Input';
 import Collapse from 'material-ui/transitions/Collapse';
+import { RadioGroup, Radio, FormLabel, FormControlLabel } from 'material-ui';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
@@ -65,6 +66,15 @@ class TrailForm extends React.Component {
     this.setState({
       dialogOpen: onOff
     })
+  }
+
+  toggleEditMode = () => {
+    const { interaction, interactionChanged} = this.props;
+    if(interaction === "DRAW_MODIFY_TRAIL" ){
+      interactionChanged("DRAW_MODIFY_HYDRANTS")
+    } else {
+      interactionChanged("DRAW_MODIFY_TRAIL")
+    }
   }
 
 
@@ -131,35 +141,28 @@ class TrailForm extends React.Component {
               onChange={(e)=>{ modifyTrail(trail.get('id'), { name: e.target.value }) }}
             />
 
-            {isTrailMode ?
-            (
-              <Button
-              className={classes.root}
-              style={{marginTop: 10}}
-              color="primary"
-              onClick={()=> interactionChanged('DRAW_MODIFY_HYDRANTS')}
-              variant="raised"
-              >
-              Edit Hydrants
-              </Button>
-            ) :
-            <Button
-            className={classes.root}
-            color="primary"
-            style={{marginTop: 10}}
-            onClick={()=> interactionChanged('DRAW_MODIFY_TRAIL')}
-            variant="raised"
-            >
-              Edit Trail
-            </Button>
-
-          }
 
             <List className={classes.root}>
+
+              <ListItem disableGutters >
+                <FormControl>
+                  <Typography variant='subheading'> Edit Mode: </Typography>
+                  <RadioGroup
+                    style={{flexDirection: "row"}}
+                    value={interaction}
+                    onChange={this.toggleEditMode}
+                  >
+                    <FormControlLabel value="DRAW_MODIFY_TRAIL" control={<Radio color='primary' />} label="Trails" />
+                    <FormControlLabel value="DRAW_MODIFY_HYDRANTS" control={<Radio color='primary' />} label="Hydrants" />
+                  </RadioGroup>
+                </FormControl>
+              </ListItem>
+
               <ColorPicker
                 trail={trail}
                 modifyTrail={modifyTrail}
               />
+
               <ListItem disableGutters onClick={()=> { this.setState({ trailSectionsOpen: !this.state.trailSectionsOpen })} }>
                 <ListItemText className={classes.inset} primary="Trail Sections" />
                 {this.state.trailSectionsOpen ? <ExpandLess /> : <ExpandMore />}

--- a/src/components/TrailForm.js
+++ b/src/components/TrailForm.js
@@ -143,7 +143,6 @@ class TrailForm extends React.Component {
 
 
             <List className={classes.root}>
-
               <ListItem disableGutters >
                 <FormControl>
                   <Typography variant='subheading'> Edit Mode: </Typography>

--- a/src/components/TrailForm.js
+++ b/src/components/TrailForm.js
@@ -107,6 +107,7 @@ class TrailForm extends React.Component {
       feature.set('highlighted', true)
       feature.changed()
     }
+    
     const unhighlightFeature = (feature) => {
       feature.unset('highlighted')
       feature.changed()

--- a/src/components/TrailList.js
+++ b/src/components/TrailList.js
@@ -16,8 +16,13 @@ const CustomTableCell = withStyles(theme => ({
 
 class TrailList extends React.Component {
 
+  state = {
+    isSelected: false
+  }
+
+
   renderTrail = (trail) => {
-    const { selected, trailSelected, modifyTrail, hydrants, toggledEditing, editableTrail } = this.props;
+    const { selected, trailSelected, modifyTrail, hydrants, toggledEditing, editableTrail} = this.props;
 
     const id = trail.id;
     const isSelected = selected === id;
@@ -69,8 +74,12 @@ class TrailList extends React.Component {
   }
 
   render() {
-    const {trails, trailSelected, selected, hydrants, newTrailClicked, interactionChanged, dataImported, manualAssignmentItemsAdded, openManualAssignment, manualAssignmentItems} = this.props;
+    const {trails, trailSelected, selected, hydrants, newTrailClicked,
+      interactionChanged, dataImported, manualAssignmentItemsAdded, openManualAssignment,
+      manualAssignmentItems, toggleOrphanSelect, orphanRowSelected  } = this.props;
+
     const orphanCount = hydrants.filter((h) => h.get('trail') === null).size;
+
 
     return (
       <div>
@@ -85,9 +94,9 @@ class TrailList extends React.Component {
             <TableBody style={{overflowY: 'auto', height: '100%', width: '95%'}}>
               {orphanCount ? (
                 <TableRow
-                  className={selected === null ? 'selected' : ''}
+                  className={ orphanRowSelected ? 'selected': ''}
                   style={{borderTop: '2px solid black', cursor: 'pointer'}}
-                  onClick={(e) => { e.stopPropagation(); trailSelected(null)}}
+                  onClick={(e) => { e.stopPropagation(); toggleOrphanSelect();}}
                 >
                   <TableCell padding="dense">Orphans</TableCell>
                   <TableCell padding="dense">{orphanCount}</TableCell>

--- a/src/redux/ActionTypes.js
+++ b/src/redux/ActionTypes.js
@@ -10,7 +10,8 @@ const ActionTypes = keyMirror({
   HYDRANT_ADDED: null,
   HYDRANT_MODIFIED: null,
   HYDRANT_DELETED: null,
-
+  
+  ORPHANS_SELECTED: null,
   TRAIL_SELECTED: null,
   INTERACTION_CHANGED: null,
   HYDRANT_SELECTED: null,

--- a/src/redux/reducers/AutoAssignmentReducer.js
+++ b/src/redux/reducers/AutoAssignmentReducer.js
@@ -31,7 +31,7 @@ export default (state = initialState, action) => {
     }
     case MANUAL_ASSIGNMENT_ITEMS_ADDED: {
       return {
-        ...state, 
+        ...state,
         manualAssignmentItems: action.data
       };
     }

--- a/src/redux/reducers/HydrantReducer.js
+++ b/src/redux/reducers/HydrantReducer.js
@@ -42,6 +42,7 @@ export default (state = initialState, action) => {
       const { hydrants } = state;
       const hydrant = action.data;
       const newHydrants = hydrants.set(hydrant.id, hydrant);
+
       return {
         ...state,
         hydrants: newHydrants,
@@ -49,6 +50,7 @@ export default (state = initialState, action) => {
     }
     case HYDRANT_DELETED: {
       const hydrantId = action.data.selected;
+      
       return {
         ...state,
         hydrants: state.hydrants.delete(hydrantId),

--- a/src/redux/reducers/HydrantReducer.js
+++ b/src/redux/reducers/HydrantReducer.js
@@ -13,6 +13,7 @@ const {
   TRAIL_DELETED,
   MANUAL_ASSIGNMENT_HYDRANT_FOCUSED,
   MANUAL_ASSIGNMENT_CLOSED,
+  ORPHANS_SELECTED
 } = ActionTypes;
 
 const initialState = {
@@ -38,6 +39,18 @@ function updateHydrantFeatures(hydrant, editedFields) {
 
 export default (state = initialState, action) => {
   switch (action.type) {
+    case ORPHANS_SELECTED: {
+      state.hydrants
+        .filter(h => h.get('trail') === null)
+        .forEach(hydrant => {
+          const feature = hydrant.get('feature');
+          feature.set('selected', action.data);
+          feature.changed();
+          })
+      return {
+        ...state
+      }
+    }
     case HYDRANT_ADDED: {
       const { hydrants } = state;
       const hydrant = action.data;
@@ -50,7 +63,7 @@ export default (state = initialState, action) => {
     }
     case HYDRANT_DELETED: {
       const hydrantId = action.data.selected;
-      
+
       return {
         ...state,
         hydrants: state.hydrants.delete(hydrantId),

--- a/src/redux/reducers/TrailReducer.js
+++ b/src/redux/reducers/TrailReducer.js
@@ -28,7 +28,6 @@ function updateTrailFeatures(trail, editedFields) {
 }
 
 
-
 export default (state = initialState, action) => {
   switch (action.type) {
     case TRAIL_ADDED: {


### PR DESCRIPTION
This PR is in response to Scott's note on Aug 3rd and Lances note Aug 7th. 

1. Escape Key will escape the trail drawing interaction.

2. Delete Key will delete the previous line segment drawn using the drawing interaction.

3. Instead of using a button that changes names to switch between editing mode, I added a select to make things clearer.

4. Added display all orphans option. When orphans row is selected, all orphaned hydrants will display on the map.